### PR TITLE
Fix/autoscaling service linked role

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -17,7 +17,7 @@ MXD_COMMIT="55c8231420b2db31ee7b9e21186ed69df29a0dbd"
 
 # ---
 
-KUBE_CONFIG_PATH="~/.kube/config"
+export KUBE_CONFIG_PATH="~/.kube/config"
 
 function create_mvd {
     echo -e "${CY}Creating Minimum Viable Dataspace for Catena-X on AWS...${NC}"

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: MIT-0
 
 set -e
-CY='\033[0;36m'
-NC='\033[0m'
+CY="\033[0;36m"
+NC="\033[0m"
 
 # ---
 
@@ -17,7 +17,8 @@ MXD_COMMIT="55c8231420b2db31ee7b9e21186ed69df29a0dbd"
 
 # ---
 
-export KUBE_CONFIG_PATH="~/.kube/config"
+# If local Kubernetes credentials exist, make sure Terraform Helm provider uses them
+if [ -f "~/.kube/config" ]; then export KUBE_CONFIG_PATH="~/.kube/config"; fi
 
 function create_mvd {
     echo -e "${CY}Creating Minimum Viable Dataspace for Catena-X on AWS...${NC}"
@@ -62,6 +63,7 @@ function create_mvd {
         -e "s|EDC_ACCESS_KEY_ID|${edc_access_key_id}|g" -e "s|EDC_ACCESS_KEY_SECRET|${edc_access_key_secret}|g" ../../templates/main.tf.tpl > main.tf
     sed -e "s|EDC_AUTH_KEY|${edc_auth_key}|g" ../../templates/connector-values.yaml.tpl > modules/connector/values.yaml
 
+    sed -e "s|password|${edc_auth_key}|g" -i "" postman/mxd-seed.json
     cat ../../templates/connector-main.tf.tpl > modules/connector/main.tf
 
     # Deploy Tractus-X MXD

--- a/deploy.sh
+++ b/deploy.sh
@@ -25,6 +25,11 @@ function create_mvd {
     echo "Please enter an alphanumeric string to protect access to your connector APIs."
     read -s -p "EDC authentication key: " edc_auth_key
 
+    # Ensure AWSServiceRoleForAutoScaling exists to prevent https://github.com/hashicorp/terraform-provider-aws/issues/28644
+    if ! aws iam get-role --role-name AWSServiceRoleForAutoScaling >/dev/null 2>&1; then
+        aws iam create-service-linked-role --aws-service-name autoscaling.amazonaws.com >/dev/null
+    fi
+
     terraform init
     terraform apply -auto-approve
 

--- a/main.tf
+++ b/main.tf
@@ -122,15 +122,6 @@ module "eks" {
   tags = local.tags
 }
 
-data "aws_iam_roles" "autoscaling" {
-  name_regex = "AWSServiceRoleForAutoScaling"
-}
-
-resource "aws_iam_service_linked_role" "autoscaling" {
-  count = length(data.aws_iam_roles.autoscaling.arns) == 0 ? 1 : 0
-  aws_service_name = "autoscaling.amazonaws.com"
-}
-
 module "ebs_kms_key" {
 
   source = "git::https://github.com/terraform-aws-modules/terraform-aws-kms.git?ref=22226b6b6841a26e99c5e122ba947d10a43c8321"  # commit hash of version 2.2.1
@@ -148,9 +139,6 @@ module "ebs_kms_key" {
   ]
 
   tags = local.tags
-
-  # Ensure AWSServiceRoleForAutoScaling exists to prevent https://github.com/hashicorp/terraform-provider-aws/issues/28644
-  depends_on = [aws_iam_service_linked_role.autoscaling]
 }
 
 data "aws_rds_engine_version" "postgresql" {


### PR DESCRIPTION
*Description of changes:*

* [Ensure presence of AWSServiceRoleForAutoScaling service-linked role](https://github.com/aws-samples/minimum-viable-dataspace-for-catenax/commit/21763c036afe99671a1209bc2f4b3c4f1a1c8b9b)
* [Move AWSServiceRoleForAutoScaling creation from Terraform to deploy.sh](https://github.com/aws-samples/minimum-viable-dataspace-for-catenax/commit/40c284028408e8d0c56464e9fb9e99040a1e5430)
* [Fix Helm provider credentials configuration and seeding using a custom API key](https://github.com/aws-samples/minimum-viable-dataspace-for-catenax/commit/a941f8232012541c5230f39b59fac50d7fa486fe)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
